### PR TITLE
Use HTML5 push state to set the hash for a tab (with fallback)

### DIFF
--- a/js/tabber.js
+++ b/js/tabber.js
@@ -35,8 +35,8 @@
 			nav.on('click', 'a', function(e) {
 				var title = $(this).attr('title');
 				e.preventDefault();
-				if (history.pushState) {
-					history.pushState(null, null, '#' + title);
+				if ( history.pushState ) {
+					history.pushState( null, null, '#' + title );
 				} else {
 					location.hash = '#' + title;
 				}

--- a/js/tabber.js
+++ b/js/tabber.js
@@ -35,7 +35,11 @@
 			nav.on('click', 'a', function(e) {
 				var title = $(this).attr('title');
 				e.preventDefault();
-				location.hash = '#' + title;
+				if (history.pushState) {
+					history.pushState(null, null, '#' + title);
+				} else {
+					location.hash = '#' + title;
+				}
 				showContent( title );
 			});
 


### PR DESCRIPTION
This is a mirror of https://gerrit.wikimedia.org/r/#/c/389283 that I'm just filing here as well.

```
Added use of HTML5 push state with a fallback for older browsers.

Use of location.hash when a tab name is identical to a heading, will
cause the browser to jump to the respective heading via anchor tag.

One effect of using push state is that this bug is then mitigated in
modern browsers.
```

I had assumed Gerrit would be the best place originally but from the replies I've received, it seems to just be a mirror but I believe @Alexia is going to see what with this, haha.

As mentioned by Bartosz (MatmaRex on Gerrit), this obviously doesn't fix said bug but it works fine when changing tabs (that have the same title as a heading). I'll file an issue anyway.

I use this tiny fix on my personal wiki and figured it'd be worth err, upstreaming I think is the right term but it's a pretty trivial change honestly.